### PR TITLE
T-159 Fetch images from db

### DIFF
--- a/pages/api/images/[image].js
+++ b/pages/api/images/[image].js
@@ -1,0 +1,26 @@
+import nc from "next-connect";
+import { withSentry } from "@sentry/nextjs";
+import { Image } from "../../../models";
+
+const MONTH_IN_SECONDS = 2592000;
+
+const handler = nc().get(async (req, res) => {
+  const { image: imageName } = req.query;
+  const imageId = imageName.split(".")[0];
+  const image = await Image.findOne({
+    where: {
+      id: imageId,
+    },
+  });
+  if (!image) {
+    res.status(404).end();
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": "image/jpeg",
+    "Cache-Control": `public, immutable, max-age=${MONTH_IN_SECONDS}`,
+  });
+  res.end(image.file);
+});
+
+export default withSentry(handler);


### PR DESCRIPTION
### Дизайн решения

Картинки вызываются по роуту /api/images/[image_id].jpg
У нас в базе все картинки будут jpg, мы их трансформируем перед загрузкой. Так что тут я возвращаю статично image/jpeg.
Использования id в роуте мне показалось удобнее, у всех картинок он уникальный.
Преобразование в .webp и дальнейшие оптимизации уже проводит сам Next в компоненте Image. Так что тут я ничего такого не делал.

### Вопросы

1. Могут быть какие то security issue быть, как я сейчас передаю imageId в ORM? Может нужно как то очищать эту строку?
2. Никогда не указывал Cache-Control, не уверен будет ли это работать как я думаю.